### PR TITLE
Fix YOUR_WIFI_SSID_HERE bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,12 +117,12 @@
             <div id="commands">
               <div class="field">
                 <label><span>SSID:</span>
-                  <input id="network_type_wifi_native.network_ssid" class="partition-data" type="text" placeholder="WiFi SSID" value="" />
+                  <input id="network_type_wifi.network_ssid" class="partition-data" type="text" placeholder="WiFi SSID" value="" />
                 </label>
               </div>
               <div class="field">
                 <label><span>Password:</span>
-                  <input id="network_type_wifi_native.network_password" class="partition-data" type="text" placeholder="WiFi Password" value=""  />
+                  <input id="network_type_wifi.network_password" class="partition-data" type="text" placeholder="WiFi Password" value=""  />
                 </label>
               </div>
               <div class="field">


### PR DESCRIPTION
The secret.json file which is flashed to the board has SSID `YOUR_WIFI_SSID_HERE` and password `YOUR_WIFI_PASS_HERE`.

I believe this is because the input's ID did not get changed to match the change within https://github.com/adafruit/WipperSnapper_Firmware_Uploader/pull/15